### PR TITLE
chore: updates link to motherboard in BOM

### DIFF
--- a/bom.csv
+++ b/bom.csv
@@ -75,7 +75,7 @@ pneumatic-adapter-MS4M-M5,https://cdn.automationdirect.com/images/products/large
 pneumatic-tubing-4mmOD,https://cdn.automationdirect.com/images/products/large/l_pu532blk100.jpg,2,MISC,https://www.automationdirect.com/adc/shopping/catalog/pneumatic_components/flexible_pneumatic_tubing_-a-_hoses/straight_polyurethane_(pur)_tubing/5-z-32_inch_(4_mm)/pu532blk100,,,Units in meters.
 pneumatic-tubing-6mmOD,https://cdn.automationdirect.com/images/products/medium/m_pu6mblk100.jpg,0.4,MISC,https://www.automationdirect.com/adc/shopping/catalog/pneumatic_components/flexible_pneumatic_tubing_-a-_hoses/straight_polyurethane_(pur)_tubing/6_mm/pu6mblk100,,,Units in meters.
 24v-power-supply,https://avacomtech.com/pub/media/catalog/product/cache/image/1000x1320/e9c3970ab036de70892d86c6d221abfe/w/e/web1_2.png,1,MISC,,,,
-motherboard,https://cdn.shopify.com/s/files/1/0570/4256/7355/products/MoboRev03_900x.png?v=1622838969,1,PCA,https://opulo.io/products/index-motherboard-rev-03,,,
+motherboard,https://cdn.shopify.com/s/files/1/0570/4256/7355/products/MoboRev03_1728x.png?v=1622838969,1,PCA,https://opulo.io/products/lumenpnp-pcb-kit,,,
 datum-board,,1,PCA,Click link above to download source,,,
 top-ring-light,,1,PCA,Click link above to download source,,,
 bottom-ring-light,,1,PCA,Click link above to download source,,,

--- a/bom.csv
+++ b/bom.csv
@@ -76,9 +76,9 @@ pneumatic-tubing-4mmOD,https://cdn.automationdirect.com/images/products/large/l_
 pneumatic-tubing-6mmOD,https://cdn.automationdirect.com/images/products/medium/m_pu6mblk100.jpg,0.4,MISC,https://www.automationdirect.com/adc/shopping/catalog/pneumatic_components/flexible_pneumatic_tubing_-a-_hoses/straight_polyurethane_(pur)_tubing/6_mm/pu6mblk100,,,Units in meters.
 24v-power-supply,https://avacomtech.com/pub/media/catalog/product/cache/image/1000x1320/e9c3970ab036de70892d86c6d221abfe/w/e/web1_2.png,1,MISC,,,,
 motherboard,https://cdn.shopify.com/s/files/1/0570/4256/7355/products/MoboRev03_1728x.png?v=1622838969,1,PCA,https://opulo.io/products/lumenpnp-pcb-kit,,,
-datum-board,,1,PCA,Click link above to download source,,,
-top-ring-light,,1,PCA,Click link above to download source,,,
-bottom-ring-light,,1,PCA,Click link above to download source,,,
+datum-board,,1,PCA,Click link above to download source,https://opulo.io/products/lumenpnp-pcb-kit,,
+top-ring-light,,1,PCA,Click link above to download source,https://opulo.io/products/lumenpnp-pcb-kit,,
+bottom-ring-light,,1,PCA,Click link above to download source,https://opulo.io/products/lumenpnp-pcb-kit,,
 limit-switch-board,https://m.media-amazon.com/images/I/51EsYhyjJAL.jpg,3,PCA,https://www.amazon.com/D-FLIFE-Printer-Mechanical-Switches-Makerbot/dp/B089K5MX21,,,
 usb-camera,http://www.elpcctv.com/bmz_cache/d/d715533992081472c5ceee925620187d.image.300x300.jpg,2,MISC,https://www.ebay.com/itm/224472204831,,,
 cp40-holder,https://www.robotdigg.com/crab/image/2016/09/24/2dc797b0066ef492441f43c2f25c37a9-300-300.jpeg,1,MISC,https://www.robotdigg.com/product/799/OpenPnP-CP40-Holder,https://www.alibaba.com/product-detail/SMT-SPARE-PARTS-SAMSUNG-CP40-NOZZLE_60863912898.html?spm=a2700.galleryofferlist.normal_offer.d_title.795d3049d6w6hc,,


### PR DESCRIPTION
This PR updates the location of the motherboard: the existing link didn't work for that in the BOM. Additionally, I went ahead and added the other boards included in that kit to the `Source 2` column. I didn't add all of the materials included in the kit (e.g., the TMC2209 stepper motors... it was not clear to me if these are a replacement for the NEMA17 motors, so I left it alone).