### PR TITLE
Put fiducials in position file

### DIFF
--- a/.github/workflows/scripts/kibot/config-2layer.kibot.yaml
+++ b/.github/workflows/scripts/kibot/config-2layer.kibot.yaml
@@ -165,6 +165,7 @@ outputs:
     dir: gerbers
     options:
       format: CSV
+      variant: ''
 
   - name: 'bom_jlc'
     comment: "BoM for JLC"

--- a/.github/workflows/scripts/kibot/config-4layer.kibot.yaml
+++ b/.github/workflows/scripts/kibot/config-4layer.kibot.yaml
@@ -175,6 +175,7 @@ outputs:
     dir: gerbers
     options:
       format: CSV
+      variant: ''
 
   - name: 'bom_jlc'
     comment: "BoM for JLC"

--- a/.github/workflows/scripts/kibot/config.kibot.yaml
+++ b/.github/workflows/scripts/kibot/config.kibot.yaml
@@ -179,6 +179,7 @@ outputs:
     dir: gerbers
     options:
       format: CSV
+      variant: ''
 
   - name: 'bom_jlc'
     comment: "BoM for JLC"


### PR DESCRIPTION
As the global is set to use the "default" variant that we have set to be "kibom" type, the position files inherit the _mechanical filter which remove unuseful pads from the pick and place file.  Fiduals are hence not in the position file normally if the _mechanical filter is applied.

see the generic filter explanation;
https://github.com/INTI-CMNB/KiBot#supported-filters 
and the supported variant default value of filter (`exclude_filter`) ; 
https://github.com/INTI-CMNB/KiBot#supported-variants

Fix issue #566 