### PR TITLE
Make a pos file for setting up FTP board positioning

### DIFF
--- a/.github/workflows/scripts/kibot/config-2layer.kibot.yaml
+++ b/.github/workflows/scripts/kibot/config-2layer.kibot.yaml
@@ -159,12 +159,20 @@ outputs:
       format: png
       bottom: true
 
-  - name: 'pick_and_place_file'
+  - name: 'pick_and_place_file for .csv files'
     comment: 'Pick and Place Location File'
     type: position
     dir: gerbers
     options:
       format: CSV
+
+  - name: 'pick_and_place_file for .pos files'
+    comment: 'Position File'
+    type: position
+    dir: gerbers
+    options:
+      format: ASCII
+      variant: ''
 
   - name: 'bom_jlc'
     comment: "BoM for JLC"


### PR DESCRIPTION
The documentation is based on the `.pos` file being available in the release bundle, but was missing as it was a csv file instead. This commit will make a new position file based on ASCII and should output 2 files for top and bottom (as .pos)