### PR TITLE
FIx STL artifacts zip inside zip

### DIFF
--- a/.github/workflows/export-mcad.yaml
+++ b/.github/workflows/export-mcad.yaml
@@ -83,7 +83,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: LumenPnP-DXFs
-        path: ~/LumenPnP-DXFs.zip
+        path: .github/workflows/scripts/csm-export/*.dxf
         if-no-files-found: warn
         retention-days: 60
 

--- a/.github/workflows/export-mcad.yaml
+++ b/.github/workflows/export-mcad.yaml
@@ -65,20 +65,16 @@ jobs:
         cd .github/workflows/scripts/stl-export
         zip -9 -j /home/runner/work/lumenpnp/lumenpnp/LumenPnP-STLs-${{ github.event.release.tag_name }}.zip *.stl
         cd ../csm-export
-
-    - name: Compress STL and DXF files for Artifacts
-      if: github.event_name != 'release'
-      run: |
-        cd .github/workflows/scripts/stl-export
-        zip -9 -j ~/LumenPnP-STLs.zip *.stl
-        cd /home/runner/work/lumenpnp/lumenpnp/.github/workflows/scripts/csm-export
+        if [ -f "*.dxf" ]; then
+        zip -9 -j /home/runner/work/lumenpnp/lumenpnp/LumenPnP-DXFs-${{ github.event.release.tag_name }}.zip *.dxf
+        fi
 
     - name: Upload STLs as Artifacts
       if: github.event_name != 'release'
       uses: actions/upload-artifact@v2
       with:
         name: LumenPnP-STLs
-        path: ~/LumenPnP-STLs.zip
+        path: .github/workflows/scripts/stl-export/*.stl
         if-no-files-found: error
         retention-days: 60
 
@@ -95,4 +91,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: github.event_name == 'release'
       with:
-        files: LumenPnP-STLs-${{ github.event.release.tag_name }}.zip
+        files: |
+          LumenPnP-STLs-${{ github.event.release.tag_name }}.zip
+          LumenPnP-DXFs-${{ github.event.release.tag_name }}.zip
+        fail_on_unmatched_files: false


### PR DESCRIPTION
STL artifacts of GitHub action were being placed in a zip inside a zip.

In the same go I' have fixed DXF generation if they are included in the future. I saw that there were things on the workflow regarding DXFs that were doing things but they're output wasn't being used so I would rather delete it or complete it. I've chose to complete it making it conditionally export DXFs if there are any. I understood the script was like it was because currently we have no DXFs and we wanted to keep the code handy in the event we have DXFs again. Hope this is helpful!